### PR TITLE
merge(custom_db_pool): add custom connection pool options;

### DIFF
--- a/migrations/U1__pragma.sql
+++ b/migrations/U1__pragma.sql
@@ -1,1 +1,0 @@
-PRAGMA foreign_keys = ON

--- a/src/api/data/users.rs
+++ b/src/api/data/users.rs
@@ -10,7 +10,7 @@ use rocket_sync_db_pools::rusqlite::{params, params_from_iter, Error, Row, Trans
 use crate::{
     api::data::permissions::{permissions_from_row, Permission},
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 #[derive(Deserialize)]
@@ -81,7 +81,7 @@ impl<'r> FromRequest<'r> for User {
     type Error = ApiError;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<User, Self::Error> {
-        let db = match request.guard::<Database>().await {
+        let db = match request.guard::<MyDatabase>().await {
             Outcome::Success(db) => db,
             Outcome::Forward(f) => return Outcome::Forward(f),
             Outcome::Error((e, _)) => {

--- a/src/api/endpoints/albums.rs
+++ b/src/api/endpoints/albums.rs
@@ -161,8 +161,6 @@ async fn album_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     }
 
     db.run(move |conn| -> Result<()> {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         if let Err(QueryReturnedNoRows) =

--- a/src/api/endpoints/albums.rs
+++ b/src/api/endpoints/albums.rs
@@ -4,13 +4,13 @@ use rocket_sync_db_pools::rusqlite::{params, Error::QueryReturnedNoRows, ToSql};
 use crate::{
     api::data::{albums::Album, permissions::Permission, users::User},
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/album", data = "<album>")]
-async fn album_write(db: Database, user: User, album: Json<Album>) -> Result<Json<Album>> {
+async fn album_write(db: MyDatabase, user: User, album: Json<Album>) -> Result<Json<Album>> {
     if !user.permissions.contains(&Permission::AlbumWrite) {
         Err(Status::Forbidden)?
     }
@@ -55,7 +55,7 @@ async fn album_write(db: Database, user: User, album: Json<Album>) -> Result<Jso
 
 #[get("/album?<id>&<name>&<maxrelease>&<minrelease>&<genres>&<maxcount>&<mincount>&<limit>")]
 async fn album_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     id: Option<String>,
     name: Option<String>,
@@ -155,7 +155,7 @@ async fn album_get(
 }
 
 #[delete("/album/<id>")]
-async fn album_delete(db: Database, user: User, id: String) -> Result<()> {
+async fn album_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     if !user.permissions.contains(&Permission::AlbumDelete) {
         Err(Status::Forbidden)?
     }

--- a/src/api/endpoints/artists.rs
+++ b/src/api/endpoints/artists.rs
@@ -3,14 +3,14 @@ use rocket_sync_db_pools::rusqlite::{params, Error::QueryReturnedNoRows, ToSql};
 
 use crate::{
     error::ApiError,
-    database::Database, 
+    database::MyDatabase, 
     api::data::{artists::Artist, permissions::Permission, users::User},
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/artist", data = "<artist>")]
-async fn artist_write(db: Database, user: User, artist: Json<Artist>) -> Result<Json<Artist>> {
+async fn artist_write(db: MyDatabase, user: User, artist: Json<Artist>) -> Result<Json<Artist>> {
     if !user.permissions.contains(&Permission::ArtistWrite) {
         Err(Status::Forbidden)?
     }
@@ -53,7 +53,7 @@ async fn artist_write(db: Database, user: User, artist: Json<Artist>) -> Result<
 
 #[get("/artist?<id>&<name>&<genres>&<limit>")]
 async fn artist_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     id: Option<String>,
     name: Option<String>,
@@ -111,7 +111,7 @@ async fn artist_get(
 }
 
 #[delete("/artist/<id>")]
-async fn artist_delete(db: Database, user: User, id: String) -> Result<()> {
+async fn artist_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     if !user.permissions.contains(&Permission::ArtistDelete) {
         Err(Status::Forbidden)?
     }

--- a/src/api/endpoints/artists.rs
+++ b/src/api/endpoints/artists.rs
@@ -117,8 +117,6 @@ async fn artist_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     }
 
     db.run(move |conn| -> Result<()> {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         if let Err(QueryReturnedNoRows) = tx.query_row(

--- a/src/api/endpoints/genres.rs
+++ b/src/api/endpoints/genres.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::ApiError,
-    database::Database, 
+    database::MyDatabase, 
     api::data::{permissions::Permission, users::User},
 };
 use rocket::{fairing::AdHoc, http::Status, serde::json::Json};
@@ -9,7 +9,7 @@ use rocket_sync_db_pools::rusqlite::{params, Error::QueryReturnedNoRows, ToSql};
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/genre/<genre>")]
-async fn genre_write(db: Database, user: User, genre: String) -> Result<Json<String>> {
+async fn genre_write(db: MyDatabase, user: User, genre: String) -> Result<Json<String>> {
     if !user.permissions.contains(&Permission::GenreWrite) {
         Err(Status::Forbidden)?
     }
@@ -23,7 +23,7 @@ async fn genre_write(db: Database, user: User, genre: String) -> Result<Json<Str
 
 #[get("/genre?<genre>&<limit>")]
 async fn genre_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     genre: Option<String>,
     limit: Option<u16>,
@@ -57,7 +57,7 @@ async fn genre_get(
 }
 
 #[delete("/genre/<genre>")]
-async fn genre_delete(db: Database, user: User, genre: String) -> Result<()> {
+async fn genre_delete(db: MyDatabase, user: User, genre: String) -> Result<()> {
     if !user.permissions.contains(&Permission::GenreDelete) {
         Err(Status::Forbidden)?
     }

--- a/src/api/endpoints/genres.rs
+++ b/src/api/endpoints/genres.rs
@@ -63,8 +63,6 @@ async fn genre_delete(db: MyDatabase, user: User, genre: String) -> Result<()> {
     }
 
     db.run(move |conn| -> Result<()> {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         if let Err(QueryReturnedNoRows) =

--- a/src/api/endpoints/invites.rs
+++ b/src/api/endpoints/invites.rs
@@ -8,14 +8,14 @@ use crate::{
         users::{DangerousLogin, User},
     },
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 // creates a new account
 #[post("/invite/<code>", data = "<login>")]
-async fn invite_use(db: Database, code: String, login: Json<DangerousLogin>) -> Result<()> {
+async fn invite_use(db: MyDatabase, code: String, login: Json<DangerousLogin>) -> Result<()> {
     let login = login.into_inner();
 
     db.run(move |conn| -> Result<()> {
@@ -51,7 +51,7 @@ async fn invite_use(db: Database, code: String, login: Json<DangerousLogin>) -> 
 }
 
 #[post("/invite", data = "<invite>")]
-async fn invite_write(db: Database, user: User, invite: Json<Invite>) -> Result<Json<Invite>> {
+async fn invite_write(db: MyDatabase, user: User, invite: Json<Invite>) -> Result<Json<Invite>> {
     let mut invite = invite.into_inner();
     let mut required_permissions = invite.permissions.to_owned();
     required_permissions.push(Permission::InviteWrite);
@@ -115,7 +115,7 @@ async fn invite_write(db: Database, user: User, invite: Json<Invite>) -> Result<
 
 #[get("/invite?<code>&<permissions>&<maxremaining>&<minremaining>&<creator>&<limit>")]
 async fn invite_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     code: Option<String>,
     permissions: Option<Json<Vec<Permission>>>,
@@ -176,7 +176,7 @@ async fn invite_get(
 }
 
 #[delete("/invite/<code>")]
-async fn invite_delete(db: Database, user: User, code: String) -> Result<()> {
+async fn invite_delete(db: MyDatabase, user: User, code: String) -> Result<()> {
     if !user.permissions.contains(&Permission::InviteDelete) {
         return Err(Status::Forbidden)?;
     }

--- a/src/api/endpoints/permissions.rs
+++ b/src/api/endpoints/permissions.rs
@@ -7,14 +7,14 @@ use crate::{
         users::User,
     },
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/permissions/<username>", data = "<permissions_to_add>")]
 async fn permissions_add(
-    db: Database,
+    db: MyDatabase,
     user: User,
     username: String,
     permissions_to_add: Json<Vec<Permission>>,
@@ -59,7 +59,7 @@ async fn permissions_add(
 
 #[delete("/permissions/<username>", data = "<permissions_to_delete>")]
 async fn permissions_delete(
-    db: Database,
+    db: MyDatabase,
     user: User,
     username: String,
     permissions_to_delete: Json<Vec<Permission>>,

--- a/src/api/endpoints/permissions.rs
+++ b/src/api/endpoints/permissions.rs
@@ -67,8 +67,6 @@ async fn permissions_delete(
     let permissions_to_delete = permissions_to_delete.into_inner();
 
     db.run(move |conn| {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         let mut required_permissions = tx.query_row(

--- a/src/api/endpoints/tokens.rs
+++ b/src/api/endpoints/tokens.rs
@@ -13,14 +13,14 @@ use crate::{
         users::{DangerousLogin, User},
     },
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/token", data = "<login>")]
 async fn token_write(
-    db: Database,
+    db: MyDatabase,
     jar: &CookieJar<'_>,
     login: Json<DangerousLogin>,
 ) -> Result<Json<String>> {
@@ -56,7 +56,7 @@ async fn token_write(
 }
 
 #[delete("/token/<username>")]
-async fn token_delete(db: Database, user: User, username: String) -> Result<()> {
+async fn token_delete(db: MyDatabase, user: User, username: String) -> Result<()> {
     if username != user.username && !user.permissions.contains(&Permission::TokenDelete) {
         Err(Status::Forbidden)?
     }

--- a/src/api/endpoints/tokens.rs
+++ b/src/api/endpoints/tokens.rs
@@ -12,8 +12,8 @@ use crate::{
         permissions::Permission,
         users::{DangerousLogin, User},
     },
-    error::ApiError,
     database::MyDatabase,
+    error::ApiError,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
@@ -61,11 +61,8 @@ async fn token_delete(db: MyDatabase, user: User, username: String) -> Result<()
         Err(Status::Forbidden)?
     }
 
-    db.run(move |conn| {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-        conn.execute("DELETE FROM tokens WHERE username = ?", params![username])
-    })
-    .await?;
+    db.run(move |conn| conn.execute("DELETE FROM tokens WHERE username = ?", params![username]))
+        .await?;
     Ok(())
 }
 

--- a/src/api/endpoints/tracks.rs
+++ b/src/api/endpoints/tracks.rs
@@ -171,8 +171,6 @@ async fn track_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     }
 
     db.run(move |conn| -> Result<()> {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         if let Err(QueryReturnedNoRows) =

--- a/src/api/endpoints/tracks.rs
+++ b/src/api/endpoints/tracks.rs
@@ -4,13 +4,13 @@ use rocket_sync_db_pools::rusqlite::{params, Error::QueryReturnedNoRows, ToSql};
 use crate::{
     api::data::{permissions::Permission, tracks::Track, users::User},
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
 };
 
 type Result<T> = std::result::Result<T, ApiError>;
 
 #[post("/track", data = "<track>")]
-async fn track_write(db: Database, user: User, track: Json<Track>) -> Result<Json<Track>> {
+async fn track_write(db: MyDatabase, user: User, track: Json<Track>) -> Result<Json<Track>> {
     if !user.permissions.contains(&Permission::TrackWrite) {
         Err(Status::Forbidden)?
     }
@@ -56,7 +56,7 @@ async fn track_write(db: Database, user: User, track: Json<Track>) -> Result<Jso
 
 #[get("/track?<id>&<name>&<maxrelease>&<minrelease>&<genres>&<albums>&<artists>&<lyrics>&<limit>")]
 async fn track_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     id: Option<String>,
     name: Option<String>,
@@ -165,7 +165,7 @@ async fn track_get(
 }
 
 #[delete("/track/<id>")]
-async fn track_delete(db: Database, user: User, id: String) -> Result<()> {
+async fn track_delete(db: MyDatabase, user: User, id: String) -> Result<()> {
     if !user.permissions.contains(&Permission::TrackDelete) {
         Err(Status::Forbidden)?
     }

--- a/src/api/endpoints/users.rs
+++ b/src/api/endpoints/users.rs
@@ -4,7 +4,7 @@ use strum::IntoEnumIterator;
 
 use crate::{
     error::ApiError,
-    database::Database,
+    database::MyDatabase,
     api::data::{
         permissions::{Permission, permissions_from_row},
         users::{DangerousLogin, User},
@@ -15,7 +15,7 @@ type Result<T> = std::result::Result<T, ApiError>;
 
 // create the first user in the database
 #[post("/init", data = "<login>")]
-async fn user_init(db: Database, login: Json<DangerousLogin>) -> Result<()> {
+async fn user_init(db: MyDatabase, login: Json<DangerousLogin>) -> Result<()> {
     let login = login.into_inner();
 
     db.run(move |conn| -> Result<()> {
@@ -41,7 +41,7 @@ async fn user_init(db: Database, login: Json<DangerousLogin>) -> Result<()> {
 
 #[get("/user?<username>&<permissions>&<limit>")]
 async fn user_get(
-    db: Database,
+    db: MyDatabase,
     user: User,
     username: Option<String>,
     permissions: Option<Json<Vec<Permission>>>,
@@ -84,7 +84,7 @@ async fn user_get(
 }
 
 #[delete("/user/<username>")]
-async fn user_delete(db: Database, user: User, username: &str) -> Result<()> {
+async fn user_delete(db: MyDatabase, user: User, username: &str) -> Result<()> {
     let username = username.to_string(); // Fix Message: Using `String` as a parameter type is inefficient. Use `&str` instead.
     db.run(move |conn| -> Result<()> {
         conn.execute_batch("PRAGMA foreign_keys = ON;")?;

--- a/src/api/endpoints/users.rs
+++ b/src/api/endpoints/users.rs
@@ -87,8 +87,6 @@ async fn user_get(
 async fn user_delete(db: MyDatabase, user: User, username: &str) -> Result<()> {
     let username = username.to_string(); // Fix Message: Using `String` as a parameter type is inefficient. Use `&str` instead.
     db.run(move |conn| -> Result<()> {
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-
         let tx = conn.transaction()?;
 
         if username != user.username {

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1,0 +1,89 @@
+use rocket::{serde, Build, Rocket};
+use rocket_sync_db_pools::{
+    r2d2,
+    rusqlite,
+    Config, PoolResult, Poolable,
+};
+
+use std::ops::{Deref, DerefMut};
+use std::time::Duration;
+
+use crate::database::MyPoolManager;
+
+/// a wrapper for rusqlite's Connection
+///
+/// the is mostly yoinked from rocket_sync_db_pools implementation of Poolable for rusqlite Connection
+pub struct MyConnection(pub rusqlite::Connection);
+
+impl Poolable for MyConnection {
+    type Manager = MyPoolManager;
+    type Error = std::convert::Infallible;
+
+    fn pool(db_name: &str, rocket: &Rocket<Build>) -> PoolResult<Self> {
+        use rocket::figment::providers::Serialized;
+
+        #[derive(Debug, serde::Deserialize, serde::Serialize)]
+        #[serde(crate = "rocket::serde", rename_all = "snake_case")]
+        enum OpenFlag {
+            ReadOnly,
+            ReadWrite,
+            Create,
+            Uri,
+            Memory,
+            NoMutex,
+            FullMutex,
+            SharedCache,
+            PrivateCache,
+            Nofollow,
+        }
+
+        let figment = Config::figment(db_name, rocket);
+        let config: Config = figment.extract()?;
+        let open_flags: Vec<OpenFlag> = figment
+            .join(Serialized::default("open_flags", <Vec<OpenFlag>>::new()))
+            .extract_inner("open_flags")?;
+
+        let mut flags = rusqlite::OpenFlags::default();
+        for flag in open_flags {
+            let sql_flag = match flag {
+                OpenFlag::ReadOnly => rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+                OpenFlag::ReadWrite => rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+                OpenFlag::Create => rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
+                OpenFlag::Uri => rusqlite::OpenFlags::SQLITE_OPEN_URI,
+                OpenFlag::Memory => rusqlite::OpenFlags::SQLITE_OPEN_MEMORY,
+                OpenFlag::NoMutex => rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+                OpenFlag::FullMutex => rusqlite::OpenFlags::SQLITE_OPEN_FULL_MUTEX,
+                OpenFlag::SharedCache => rusqlite::OpenFlags::SQLITE_OPEN_SHARED_CACHE,
+                OpenFlag::PrivateCache => rusqlite::OpenFlags::SQLITE_OPEN_PRIVATE_CACHE,
+                OpenFlag::Nofollow => rusqlite::OpenFlags::SQLITE_OPEN_NOFOLLOW,
+            };
+
+            flags.insert(sql_flag)
+        }
+
+        let manager = MyPoolManager::new(&*config.url)
+            .with_flags(flags)
+            .with_init(|conn| conn.execute_batch("PRAGMA foreign_keys = ON;")); // custom options
+
+        let pool = r2d2::Pool::builder()
+            .max_size(config.pool_size)
+            .connection_timeout(Duration::from_secs(config.timeout as u64))
+            .build(manager)?;
+
+        Ok(pool)
+    }
+}
+
+impl Deref for MyConnection {
+    type Target = rusqlite::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MyConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -8,9 +8,9 @@ mod embedded {
 }
 
 #[database("db")]
-pub struct Database(MyConnection);
+pub struct MyDatabase(MyConnection);
 
-impl Database {
+impl MyDatabase {
     pub async fn migrations(&self) -> Result<(), Error> {
         self.run(|conn| -> Result<(), Error> {
             embedded::migrations::runner().run(&mut conn.0).unwrap();

--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -1,7 +1,6 @@
-use rocket_sync_db_pools::{
-    database,
-    rusqlite::{Connection, Error},
-};
+use rocket_sync_db_pools::{database, rusqlite::Error};
+
+use crate::database::MyConnection;
 
 mod embedded {
     use refinery::embed_migrations;
@@ -9,12 +8,12 @@ mod embedded {
 }
 
 #[database("db")]
-pub struct Database(Connection);
+pub struct Database(MyConnection);
 
 impl Database {
     pub async fn migrations(&self) -> Result<(), Error> {
         self.run(|conn| -> Result<(), Error> {
-            embedded::migrations::runner().run(conn).unwrap();
+            embedded::migrations::runner().run(&mut conn.0).unwrap();
 
             Ok(())
         })

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,7 +1,12 @@
 use rocket::fairing::AdHoc;
 
 mod database;
+mod connection;
+mod pool_manager;
+
 pub use database::Database;
+pub use connection::MyConnection;
+pub use pool_manager::MyPoolManager;
 
 pub fn fairing() -> AdHoc {
     AdHoc::on_ignite("Database Systems", |rocket| async {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -4,16 +4,16 @@ mod database;
 mod connection;
 mod pool_manager;
 
-pub use database::Database;
+pub use database::MyDatabase;
 pub use connection::MyConnection;
 pub use pool_manager::MyPoolManager;
 
 pub fn fairing() -> AdHoc {
     AdHoc::on_ignite("Database Systems", |rocket| async {
-        rocket.attach(Database::fairing()).attach(AdHoc::on_ignite(
+        rocket.attach(MyDatabase::fairing()).attach(AdHoc::on_ignite(
             "Database Migrations",
             |rocket| async {
-                <Database>::get_one(&rocket)
+                <MyDatabase>::get_one(&rocket)
                     .await
                     .expect("Mount Database")
                     .migrations()

--- a/src/database/pool_manager.rs
+++ b/src/database/pool_manager.rs
@@ -24,11 +24,11 @@ impl r2d2::ManageConnection for MyPoolManager {
     fn connect(&self) -> Result<MyConnection, Error> {
         rusqlite::Connection::open_with_flags(&self.path, self.flags)
             .map_err(Into::into)
-            .and_then(|c| match self.on_init {
-                None => Ok(MyConnection(c)),
+            .and_then(|rusqlite_connection| match self.on_init {
+                None => Ok(MyConnection(rusqlite_connection)),
                 Some(ref on_init) => {
-                    let mut my_conn = MyConnection(c);
-                    on_init(&mut my_conn).map(|_| my_conn)
+                    let mut my_connection = MyConnection(rusqlite_connection);
+                    on_init(&mut my_connection).map(|_| my_connection)
                 }
             })
     }

--- a/src/database/pool_manager.rs
+++ b/src/database/pool_manager.rs
@@ -1,0 +1,65 @@
+use rocket_sync_db_pools::{
+    r2d2,
+    rusqlite::{self, Error},
+};
+use std::path::{Path, PathBuf};
+
+use crate::database::MyConnection;
+
+type OnInitFn = dyn Fn(&mut MyConnection) -> Result<(), rusqlite::Error> + Send + Sync + 'static;
+
+/// A pool manager for MyConnection to implement the Poolable trait
+///
+/// this is mostly yoinked from the crate r2d2_sqlite
+pub struct MyPoolManager {
+    path: PathBuf,
+    flags: rusqlite::OpenFlags,
+    on_init: Option<Box<OnInitFn>>,
+}
+
+impl r2d2::ManageConnection for MyPoolManager {
+    type Connection = MyConnection;
+    type Error = rusqlite::Error;
+
+    fn connect(&self) -> Result<MyConnection, Error> {
+        rusqlite::Connection::open_with_flags(&self.path, self.flags)
+            .map_err(Into::into)
+            .and_then(|c| match self.on_init {
+                None => Ok(MyConnection(c)),
+                Some(ref on_init) => {
+                    let mut my_conn = MyConnection(c);
+                    on_init(&mut my_conn).map(|_| my_conn)
+                }
+            })
+    }
+
+    fn is_valid(&self, conn: &mut MyConnection) -> Result<(), Error> {
+        conn.execute_batch("").map_err(Into::into)
+    }
+
+    fn has_broken(&self, _: &mut MyConnection) -> bool {
+        false
+    }
+}
+
+impl MyPoolManager {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            flags: rusqlite::OpenFlags::default(),
+            on_init: None,
+        }
+    }
+
+    pub fn with_flags(self, flags: rusqlite::OpenFlags) -> Self {
+        Self { flags, ..self }
+    }
+
+    pub fn with_init<F>(self, on_init: F) -> Self
+    where
+        F: Fn(&mut MyConnection) -> Result<(), rusqlite::Error> + Send + Sync + 'static,
+    {
+        let on_init: Option<Box<OnInitFn>> = Some(Box::new(on_init));
+        Self { on_init, ..self }
+    }
+}


### PR DESCRIPTION
previously the pragma options needed to be set by each endpoint that used them. 
> because `rocket_sync_db_pools` does not support custom pool settings.

&nbsp;
See:
https://github.com/rwf2/Rocket/discussions/2752

This PR implements the workaround I mentioned in that discussion.
&nbsp;

[feat(conn_pool): add MyConnection & MyPoolManager;](https://github.com/5-pebbles/tuna/commit/de681152f8136278915fc58943ec2527434f34de)

[feat(database): implement the new connection;](https://github.com/5-pebbles/tuna/commit/b308dff0310cc892fe32275ca3ba291387cd00c4)

[refactor(database): mv Database -> MyDatabase;](https://github.com/5-pebbles/tuna/commit/65f52f41321d42ca524dff5840d3000877b06d9e)

[fix(sql): rm pragma sets on individual endpoints;](https://github.com/5-pebbles/tuna/commit/61c728382e8f3087e430750351cf7d2bafdaad92)