### PR TITLE
merge(permissions): mv permissions endpoints to permission;

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,8 +78,8 @@
         "tags": [
           "genres"
         ],
-        "summary": "Search for a genre in the database.",
-        "description": "Search for a genre in the database.\n\nRequires: `GenreRead` permission.",
+        "summary": "Retrieve a list of genres from the database.",
+        "description": "Retrieve a list of genres from the database.\n\nRequires: `GenreRead` permission.",
         "operationId": "genre_get",
         "parameters": [
           {
@@ -466,7 +466,7 @@
         ]
       }
     },
-    "/permissions/{username}": {
+    "/permission/{username}": {
       "post": {
         "tags": [
           "permissions"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -54,9 +54,9 @@ paths:
     get:
       tags:
       - genres
-      summary: Search for a genre in the database.
+      summary: Retrieve a list of genres from the database.
       description: |-
-        Search for a genre in the database.
+        Retrieve a list of genres from the database.
 
         Requires: `GenreRead` permission.
       operationId: genre_get
@@ -325,7 +325,7 @@ paths:
       security:
       - permissions:
         - InviteDelete
-  /permissions/{username}:
+  /permission/{username}:
     post:
       tags:
       - permissions

--- a/src/api/endpoints/permissions.rs
+++ b/src/api/endpoints/permissions.rs
@@ -37,7 +37,7 @@ type Result<T> = std::result::Result<T, ApiError>;
         ("permissions" = ["PermissionAdd"])
     ),
 )]
-#[post("/permissions/<username>", data = "<permissions_to_add>")]
+#[post("/permission/<username>", data = "<permissions_to_add>")]
 async fn permission_add(
     db: MyDatabase,
     user: User,
@@ -107,7 +107,7 @@ async fn permission_add(
         ("permissions" = ["PermissionDelete"])
     ),
 )]
-#[delete("/permissions/<username>", data = "<permissions_to_delete>")]
+#[delete("/permission/<username>", data = "<permissions_to_delete>")]
 async fn permission_delete(
     db: MyDatabase,
     user: User,

--- a/tests/albums.hurl
+++ b/tests/albums.hurl
@@ -139,7 +139,7 @@ HTTP 200
 # End Delete Albums
 
 # Required Permissions
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "AlbumWrite"
 ]
@@ -159,7 +159,7 @@ HTTP 200
 [Asserts]
 jsonpath "$" count == 0
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "AlbumRead"
 ]
@@ -169,7 +169,7 @@ GET {{url}}/album
 HTTP 403
 
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "AlbumDelete"
 ]

--- a/tests/artists.hurl
+++ b/tests/artists.hurl
@@ -106,7 +106,7 @@ DELETE {{url}}/artist/0
 HTTP 200
 
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "ArtistWrite"
 ]
@@ -121,7 +121,7 @@ POST {{url}}/artist
 }
 HTTP 403
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "ArtistRead"
 ]
@@ -130,7 +130,7 @@ HTTP 200
 GET {{url}}/artist
 HTTP 403
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "ArtistDelete"
 ]

--- a/tests/genres.hurl
+++ b/tests/genres.hurl
@@ -66,7 +66,7 @@ HTTP 200
 # End Delete Genres
 
 # Required Permissions
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "GenreWrite"
 ]
@@ -75,7 +75,7 @@ HTTP 200
 POST {{url}}/genre/fakemusic
 HTTP 403
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "GenreRead"
 ]
@@ -84,7 +84,7 @@ HTTP 200
 GET {{url}}/genre
 HTTP 403
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "GenreDelete"
 ]

--- a/tests/permissions.hurl
+++ b/tests/permissions.hurl
@@ -26,7 +26,7 @@ HTTP 200
 # End Setup
 
 
-POST {{url}}/permissions/SystemTest2
+POST {{url}}/permission/SystemTest2
 [
     "InviteRead"
 ]
@@ -37,7 +37,7 @@ HTTP 200
 [Asserts]
 jsonpath "$[0].permissions" includes "InviteRead"
 
-DELETE {{url}}/permissions/SystemTest2
+DELETE {{url}}/permission/SystemTest2
 [
     "InviteRead"
 ]

--- a/tests/tracks.hurl
+++ b/tests/tracks.hurl
@@ -176,7 +176,7 @@ HTTP 200
 # End Delete Track
 
 # Required Permissions
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "TrackWrite"
 ]
@@ -197,7 +197,7 @@ HTTP 200
 [Asserts]
 jsonpath "$" count == 0
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "TrackRead"
 ]
@@ -207,7 +207,7 @@ GET {{url}}/track
 HTTP 403
 
 
-DELETE {{url}}/permissions/SystemTest
+DELETE {{url}}/permission/SystemTest
 [
     "TrackDelete"
 ]


### PR DESCRIPTION
Most endpoints are named in the singular...

So it makes sense to update this one to match the rest of the API.

BREAKING CHANGE: The permissions endpoints have been moved;