### PR TITLE
feat(docs)!: improved doc endpoint;

### DIFF
--- a/tuna-server/src/api/endpoints/docs.rs
+++ b/tuna-server/src/api/endpoints/docs.rs
@@ -41,6 +41,7 @@ fn docs_openapi(user: User, format: DocFormat) -> Result<(ContentType, String), 
         Err(Status::Forbidden)?
     }
 
+    // returns an ApiError if DocFormat::Unsupported
     let docs = generate_docs(&format)?;
 
     Ok(match format {

--- a/tuna-server/src/api/endpoints/docs.rs
+++ b/tuna-server/src/api/endpoints/docs.rs
@@ -9,7 +9,7 @@ use crate::{
     error::ApiError,
 };
 
-/// Retrieve yaml OpenAPI documentation
+/// Retrieve OpenAPI documentation
 ///
 /// Requires: `DocsRead` permission
 #[utoipa::path(
@@ -18,59 +18,40 @@ use crate::{
     (
         status = 200,
         description = "Success",
-        content_type = "application/x-yaml",
         body = String,
     ),
     (
         status = 403,
         description = "Forbidden requires permission `DocsRead`"
-    )),
-    security(
-        ("permissions" = ["DocsRead"])
-    )
-)]
-#[get("/docs/openapi.yaml")]
-fn docs_yaml(user: User) -> Result<(ContentType, String), ApiError> {
-    if !user.permissions.contains(&Permission::DocsRead) {
-        Err(Status::Forbidden)?
-    }
-
-    let yaml = generate_docs(DocFormat::YAML)?;
-    Ok((ContentType::new("application", "x-yaml"), yaml))
-}
-
-/// Retrieve json OpenAPI documentation
-///
-/// Requires: `DocsRead` permission
-#[utoipa::path(
-    get,
-    responses(
-    (
-        status = 200,
-        description = "Success",
-        content_type = "application/json",
-        body = String,
     ),
     (
-        status = 403,
-        description = "Forbidden requires permission `DocsRead`"
+        status = 418,
+        description = "Unsuported documentation format"
     )),
+    params(
+        ("format" = DocFormat, description = "The requested documentation format"),
+    ),
     security(
         ("permissions" = ["DocsRead"])
     )
 )]
-#[get("/docs/openapi.json")]
-fn docs_json(user: User) -> Result<(ContentType, String), ApiError> {
+#[get("/docs/openapi/<format>")]
+fn docs_openapi(user: User, format: DocFormat) -> Result<(ContentType, String), ApiError> {
     if !user.permissions.contains(&Permission::DocsRead) {
         Err(Status::Forbidden)?
     }
 
-    let json = generate_docs(DocFormat::PrettyJSON)?;
-    Ok((ContentType::new("application", "json"), json))
+    let docs = generate_docs(&format)?;
+
+    Ok(match format {
+        DocFormat::JSON | DocFormat::PrettyJSON => (ContentType::new("application", "json"), docs),
+        DocFormat::YAML => (ContentType::new("application", "x-yaml"), docs),
+        DocFormat::Unsupported => unreachable!(),
+    })
 }
 
 pub fn fairing() -> AdHoc {
     AdHoc::on_ignite("Docs Systems", |rocket| async {
-        rocket.mount("/", routes![docs_yaml, docs_json])
+        rocket.mount("/", routes![docs_openapi])
     })
 }

--- a/tuna-server/src/docs/mod.rs
+++ b/tuna-server/src/docs/mod.rs
@@ -1,9 +1,12 @@
+use rocket::{http::Status, request::FromParam, serde::Deserialize};
+use std::{convert::Infallible, str::FromStr};
+use strum::EnumString;
 use utoipa::{
     openapi::{
         schema::Components,
         security::{ApiKey, ApiKeyValue, SecurityScheme},
     },
-    Modify, OpenApi,
+    Modify, OpenApi, ToSchema,
 };
 
 use crate::{
@@ -18,25 +21,38 @@ use crate::{
 };
 
 #[allow(dead_code)]
+#[derive(EnumString, ToSchema, Deserialize)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+#[serde(rename_all = "lowercase", crate = "rocket::serde")]
 pub enum DocFormat {
+    #[serde(skip)]
+    Unsupported,
     JSON,
     PrettyJSON,
     YAML,
 }
 
-pub fn generate_docs(format: DocFormat) -> Result<String, ApiError> {
+impl<'r> FromParam<'r> for DocFormat {
+    type Error = Infallible;
+
+    fn from_param(param: &'r str) -> Result<Self, Self::Error> {
+        Ok(Self::from_str(param).unwrap_or(Self::Unsupported))
+    }
+}
+
+pub fn generate_docs(format: &DocFormat) -> Result<String, ApiError> {
     let openapi = ApiDoc::openapi();
     Ok(match format {
         DocFormat::JSON => openapi.to_json()?,
         DocFormat::PrettyJSON => openapi.to_pretty_json()?,
         DocFormat::YAML => openapi.to_yaml()?,
+        _ => Err(ApiError::Status(Status::ImATeapot))?,
     })
 }
 
 #[derive(OpenApi)]
 #[openapi(paths(
-        docs::docs_yaml,
-        docs::docs_json,
+        docs::docs_openapi,
         tokens::token_write,
         tokens::token_delete,
         permissions::permission_add,
@@ -54,7 +70,7 @@ pub fn generate_docs(format: DocFormat) -> Result<String, ApiError> {
         audio::audio_upload,
         audio::audio_get,
         audio::audio_delete,
-    ), components(schemas(Permission, DangerousLogin, User)), modifiers(&SecurityAddon))]
+    ), components(schemas(Permission, DangerousLogin, User, DocFormat)), modifiers(&SecurityAddon))]
 struct ApiDoc;
 
 struct SecurityAddon;

--- a/tuna-server/src/docs/mod.rs
+++ b/tuna-server/src/docs/mod.rs
@@ -1,4 +1,4 @@
-use rocket::{http::Status, request::FromParam, serde::Deserialize};
+use rocket::{request::FromParam, serde::Deserialize};
 use std::{convert::Infallible, str::FromStr};
 use strum::EnumString;
 use utoipa::{
@@ -48,7 +48,9 @@ pub fn generate_docs(format: &DocFormat) -> Result<String, ApiError> {
         DocFormat::JSON => openapi.to_json()?,
         DocFormat::PrettyJSON => openapi.to_pretty_json()?,
         DocFormat::YAML => openapi.to_yaml()?,
-        _ => Err(ApiError::Status(Status::ImATeapot))?,
+        _ => Err(ApiError::Unsupported(
+            "Error: Format Unsupported".to_string(),
+        ))?,
     })
 }
 

--- a/tuna-server/src/docs/mod.rs
+++ b/tuna-server/src/docs/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     error::ApiError,
 };
 
+/// Enum representing documentation formats.
 #[allow(dead_code)]
 #[derive(EnumString, ToSchema, Deserialize)]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
@@ -40,6 +41,7 @@ impl<'r> FromParam<'r> for DocFormat {
     }
 }
 
+/// Generates the documentation in the specified format.
 pub fn generate_docs(format: &DocFormat) -> Result<String, ApiError> {
     let openapi = ApiDoc::openapi();
     Ok(match format {

--- a/tuna-server/src/error.rs
+++ b/tuna-server/src/error.rs
@@ -4,6 +4,7 @@ use rocket_sync_db_pools::rusqlite::{Error as RusqliteError, ErrorCode as Rusqli
 use serde_json::Error as JsonError;
 use serde_yaml::Error as YamlError;
 
+/// Error returned by the API
 #[derive(Debug, Responder)]
 pub enum ApiError {
     RusqliteError((Status, String)),

--- a/tuna-server/src/error.rs
+++ b/tuna-server/src/error.rs
@@ -14,6 +14,8 @@ pub enum ApiError {
     IoError(String),
     #[response(status = 500)]
     SerdeError(String),
+    #[response(status = 418)]
+    Unsupported(String),
     Status(Status),
 }
 

--- a/tuna-server/src/lib.rs
+++ b/tuna-server/src/lib.rs
@@ -21,6 +21,7 @@ fn create_working_dir() {
     ensure_dir("./database/audio");
 }
 
+/// Launch the server
 pub fn launch() {
     create_working_dir();
 


### PR DESCRIPTION
New Endpoint:
```json
"/docs/openapi/{format}": {
  "get": {
    "tags": [
      "docs"
    ],
    "summary": "Retrieve OpenAPI documentation",
    "description": "Requires: `DocsRead` permission",
    "operationId": "docs_openapi",
    "parameters": [
      {
        "name": "format",
        "in": "path",
        "description": "The requested documentation format",
        "required": true,
        "schema": {
          "$ref": "#/components/schemas/DocFormat"
        }
      }
    ],
    "responses": {
      "200": {
        "description": "Success",
        "content": {
          "text/plain": {
            "schema": {
              "type": "string"
            }
          }
        }
      },
      "403": {
        "description": "Forbidden requires permission `DocsRead`"
      },
      "418": {
        "description": "Unsuported documentation format"
      }
    },
    "security": [
      {
        "permissions": [
          "DocsRead"
        ]
      }
    ]
  }
},
```

DocFormat Schema:
```json
"DocFormat": {
  "type": "string",
  "enum": [
    "json",
    "prettyjson",
    "yaml"
  ]
},
```

BREAKING CHANGE: doc endpoints changed;